### PR TITLE
dont assume .exe is the only executable extension on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl BuildConfig {
         } if cfg!( target_os = "windows" ) {
             match self.build_target {
                 BuildTarget::Lib( _, Profile::Main ) => matcher!( "\\.(lib|dll)$" ),
-                _ => matcher!( "\\.exe$" )
+                _ => {}
             }
         } if cfg!( target_os = "linux" ) {
             match self.build_target {


### PR DESCRIPTION
This should probably be a search over PATH_EXT in the future, but that may still have some edge cases. For instance, emscripten generates .js files which are intended to be executed and the user would likely not have in her PATH_EXT.