### PR TITLE
Replace - with _ when prefixing build target name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl BuildConfig {
 
         macro_rules! prefix_matcher {
             ($prefix:expr) => {
-                matcher!( format!( "^{}-", $prefix ) )
+                matcher!( format!( "^{}-", $prefix.replace("-", "_") ) )
             }
         };
 


### PR DESCRIPTION
When the target name gets prefixed, such as when running `cargo test`, cargo replaces hyphens with underscores in the package name when it is used as a prefix. `cargo-shim` would miss these artifacts because it was still matching with the hyphen.

(Not sure if this happens on all toolchains/platforms? I tested on 1.20 stable and nightly on OSX.)